### PR TITLE
feat(php): Add PHP 8.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 <img width="1245" alt="Screen Shot 2020-07-23 at 1 39 06 PM" src="https://user-images.githubusercontent.com/1791050/88336503-f77f9000-cce9-11ea-95ed-b8ff1fb7fb26.png">
 
+## Version Compatibility
+
+| Laravel | PHP      | Package |
+|---------|----------|---------|
+| 10.x    | 8.2-8.5  | 1.x     |
+| 11.x    | 8.2-8.5  | 1.x     |
+| 12.x    | 8.2-8.5  | 1.x     |
+
 ## Installation
 ```sh
 composer require genealabs/laravel-multi-step-progressbar

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,23 @@
         }
     ],
     "require": {
-        "illuminate/support": "^10.0",
-        "illuminate/view": "^10.0",
+        "php": "^8.2",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/view": "^10.0 || ^11.0 || ^12.0",
         "jenssegers/model": "^1.5"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "pestphp/pest": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {
             "GeneaLabs\\LaravelMultiStepProgressbar\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GeneaLabs\\LaravelMultiStepProgressbar\\Tests\\": "tests/"
         }
     },
     "extra": {
@@ -26,6 +36,9 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        },
         "sort-packages": true,
         "preferred-install": "dist"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/MultiStepProgressbarComponentTest.php
+++ b/tests/MultiStepProgressbarComponentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use GeneaLabs\LaravelMultiStepProgressbar\ProgressbarItem;
+use GeneaLabs\LaravelMultiStepProgressbar\View\Components\MultiStepProgressbarItem;
+
+it('identifies first and last items correctly', function () {
+    $component = new MultiStepProgressbarItem(
+        currentStep: '1',
+        step: '1',
+        steps: '3',
+        canJumpToStep: '0',
+        stepData: collect(),
+    );
+
+    expect($component->step)->toBe(1)
+        ->and($component->steps)->toBe(3);
+});
+
+it('calculates image states for visited items', function () {
+    $component = new MultiStepProgressbarItem(
+        currentStep: '3',
+        step: '1',
+        steps: '4',
+        canJumpToStep: '2',
+        stepData: collect(),
+    );
+
+    // Step 1 is visited (step <= canJumpToStep and step !== currentStep)
+    $bubbleImage = $component->imageForBubble();
+    expect($bubbleImage)->toBeString();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use GeneaLabs\LaravelMultiStepProgressbar\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/ProgressbarItemTest.php
+++ b/tests/ProgressbarItemTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use GeneaLabs\LaravelMultiStepProgressbar\ProgressbarItem;
+
+it('can create a progressbar item with fill', function () {
+    $item = (new ProgressbarItem)->fill([
+        'step' => 1,
+        'url' => '/step-1',
+        'title' => 'First Step',
+        'description' => 'Description here',
+        'canJumpAhead' => true,
+    ]);
+
+    expect($item->step)->toBe(1)
+        ->and($item->url)->toBe('/step-1')
+        ->and($item->title)->toBe('First Step')
+        ->and($item->description)->toBe('Description here')
+        ->and($item->can_jump_ahead)->toBeTrue();
+});
+
+it('handles empty strings gracefully', function () {
+    $item = (new ProgressbarItem)->fill([
+        'step' => 1,
+        'url' => '',
+        'title' => '',
+        'description' => '',
+        'canJumpAhead' => false,
+    ]);
+
+    expect($item->step)->toBe(1)
+        ->and($item->url)->toBe('')
+        ->and($item->title)->toBe('')
+        ->and($item->description)->toBe('')
+        ->and($item->can_jump_ahead)->toBeFalse();
+});
+
+it('converts to array with appended attributes', function () {
+    $item = (new ProgressbarItem)->fill([
+        'step' => 2,
+        'url' => '/step-2',
+        'title' => 'Second',
+        'description' => 'Desc',
+        'canJumpAhead' => false,
+    ]);
+
+    $array = $item->toArray();
+
+    expect($array)->toHaveKeys(['step', 'url', 'title', 'description', 'canJumpAhead']);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GeneaLabs\LaravelMultiStepProgressbar\Tests;
+
+use GeneaLabs\LaravelMultiStepProgressbar\Providers\Service;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            Service::class,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
Add PHP 8.5 compatibility to the package by widening the PHP and Laravel version constraints in composer.json, adding a test suite with Pest, and updating the README with a version support matrix.

## Acceptance Criteria
- [x] The feature works as described in the issue
- [x] The feature is accessible via the documented interface (API/UI/CLI)
- [x] Edge cases (empty input, invalid state) are handled gracefully
- [x] The feature is covered by at least one automated test

Fixes #3